### PR TITLE
add support for SCIP 10

### DIFF
--- a/src/scipjni.i
+++ b/src/scipjni.i
@@ -468,7 +468,11 @@
    {
       SCIP_CONS* cons;
 
+#if SCIP_VERSION_MAJOR < 10
       SCIP_CALL_ABORT( SCIPcreateConsBasicOrbitope(scip, &cons, name, vars, orbitopetype, nspcons, nblocks, usedynamicprop, resolveprop, ismodelcons, mayinteract) );
+#else
+      SCIP_CALL_ABORT( SCIPcreateConsBasicOrbitope(scip, &cons, name, vars, orbitopetype, nspcons, nblocks, resolveprop, ismodelcons, FALSE) );
+#endif
 
       return cons;
    }

--- a/src/scipjni.i
+++ b/src/scipjni.i
@@ -262,7 +262,12 @@
    {
       SCIP_CONS* cons;
 
+#if SCIP_VERSION_MAJOR < 10
       SCIP_CALL_ABORT( SCIPcreateConsBasicPseudoboolean(scip, &cons, name, linvars, nlinvars, linvals, terms, nterms, ntermvars, termvals, indvar, weight, issoftcons, intvar, lhs, rhs) );
+#else
+      assert(intvar == NULL);
+      SCIP_CALL_ABORT( SCIPcreateConsBasicPseudoboolean(scip, &cons, name, linvars, nlinvars, linvals, terms, nterms, ntermvars, termvals, indvar, weight, issoftcons, lhs, rhs) );
+#endif
 
       return cons;
    }

--- a/src/scipjni_wrap.cxx
+++ b/src/scipjni_wrap.cxx
@@ -1007,7 +1007,12 @@ namespace Swig {
    {
       SCIP_CONS* cons;
 
+#if SCIP_VERSION_MAJOR < 10
       SCIP_CALL_ABORT( SCIPcreateConsBasicPseudoboolean(scip, &cons, name, linvars, nlinvars, linvals, terms, nterms, ntermvars, termvals, indvar, weight, issoftcons, intvar, lhs, rhs) );
+#else
+      assert(intvar == NULL);
+      SCIP_CALL_ABORT( SCIPcreateConsBasicPseudoboolean(scip, &cons, name, linvars, nlinvars, linvals, terms, nterms, ntermvars, termvals, indvar, weight, issoftcons, lhs, rhs) );
+#endif
 
       return cons;
    }
@@ -1208,7 +1213,11 @@ namespace Swig {
    {
       SCIP_CONS* cons;
 
+#if SCIP_VERSION_MAJOR < 10
       SCIP_CALL_ABORT( SCIPcreateConsBasicOrbitope(scip, &cons, name, vars, orbitopetype, nspcons, nblocks, usedynamicprop, resolveprop, ismodelcons, mayinteract) );
+#else
+      SCIP_CALL_ABORT( SCIPcreateConsBasicOrbitope(scip, &cons, name, vars, orbitopetype, nspcons, nblocks, resolveprop, ismodelcons, FALSE) );
+#endif
 
       return cons;
    }


### PR DESCRIPTION
This adapts wrapper code to some API changes in upcoming SCIP 10.
With these changes, I can build JSCIPOpt for the current master branch of SCIP, and tests still pass.

I'm using this scip-10 branch now for our nightly tests of some interfaces. It should also be ok to merge this already now before any SCIP 10 releases. Whatever you prefer, @kkofler.